### PR TITLE
Add github permissions test job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CI Tests for Container Images Based on Red Hat Software Collections
 ===================================================================
 
-This repository includes necessary metadata to test Contaienr Images
+This repository includes necessary metadata to test Container Images
 Based on Red Hat Software Collections automatically, prefferably using
 Jenkins.
 
@@ -14,4 +14,8 @@ and configuration for those scripts to generate set of Jenkins Job Builder
 configs for CentOS CI, that are supposed to test GitHub pull-requests
 of Contaienr Images repositories.
 
-
+* [sclorg repositories permissions test](sclorg-permissions-test) -- scripts
+and Jenkins Job Builder configuration for job which test sclorg
+repositories permissions. It checks that only employees of Red Hat have
+push or admin permissions in repositories for container images in
+sclorg github organization.

--- a/sclorg-permissions-test/README.md
+++ b/sclorg-permissions-test/README.md
@@ -1,0 +1,35 @@
+# sclorg repositories permissions test
+
+This directory contains job configuration file, managed through [Jenkins Job
+Builder](http://ci.openstack.org/jenkins-job-builder/).
+
+Created job checks that only employees of Red Hat have push or admin
+permissions in repositories for container images in sclorg github
+organization.
+
+## Jenkins environment requirements
+
+* environmental variable GH_ACCESS_TOKEN which contains token for github user who has access to checked repositories
+* "json", "rest_client", "i18n" and "ldap" gems
+* connection to RH VPN (to access ldap.rdu.redhat.com)
+
+## Pre-requisites
+
+* installed jenkins-jobs command
+* configuration file for Jenkins Job Builder
+
+## Testing job modifications
+
+    jenkins-jobs --conf <config file> test sclorg-permissions-test.yaml
+
+This prints XML definition of the job to STDOUT.
+
+## Updating jobs
+
+The provided script can update the Jenkins jobs over the API by running JJB.
+
+    jenkins-jobs --conf <config file> update sclorg-permissions-test.yaml
+
+## Generated jobs
+
+* *SCLo-test-github-permissions*: a job which checks github repositories permissions.

--- a/sclorg-permissions-test/lib/github.rb
+++ b/sclorg-permissions-test/lib/github.rb
@@ -1,0 +1,105 @@
+require 'rest_client'
+require 'json'
+
+RESULTS_PER_PAGE=100
+
+def github_org_to_teams
+  {
+    :sclorg => github_teams('sclorg'),
+  }
+end
+
+def github_teams(org_name)
+  params = access_params
+  result = RestClient.get("https://api.github.com/orgs/#{org_name}/teams", {:params => params})
+  JSON.parse(result)
+end
+
+def team_red_hat
+  params = access_params
+  result = RestClient.get("https://api.github.com/teams/168397", {:params => params})
+  JSON.parse(result)
+end
+
+def github_team_users(team)
+  params = access_params
+  result = []
+  length = RESULTS_PER_PAGE
+  page = 1
+  while length == RESULTS_PER_PAGE
+    params['page'] = page
+    next_result = RestClient.get(team['url'] + '/members', {:params => params})
+    next_result = JSON.parse(next_result)
+    length = next_result.length
+    result += next_result
+    page += 1
+  end
+  result
+end
+
+def github_team_repos(team)
+  params = access_params
+  result = []
+  length = RESULTS_PER_PAGE
+  page = 1
+  while length == RESULTS_PER_PAGE
+    params['page'] = page
+    next_result = RestClient.get(team['url'] + '/repos', {:params => params})
+    next_result = JSON.parse(next_result)
+    length = next_result.length
+    result += next_result
+    page += 1
+  end
+  result
+end
+
+def github_repo_collaborators(repo)
+  params = access_params
+  result = []
+  length = RESULTS_PER_PAGE
+  page = 1
+  while length == RESULTS_PER_PAGE
+    params['page'] = page
+    next_result = RestClient.get(repo['url'] + '/collaborators', {:params => params})
+    next_result = JSON.parse(next_result)
+    length = next_result.length
+    result += next_result
+    page += 1
+  end
+  result
+end
+
+def github_issues
+  params = access_params(false)
+  result = []
+  length = RESULTS_PER_PAGE
+  page = 1
+  while length == RESULTS_PER_PAGE
+    params['page'] = page
+    next_result = RestClient.get("https://api.github.com/repos/openshift/origin/issues", {:params => params})
+    next_result = JSON.parse(next_result)
+    length = next_result.length
+    result += next_result
+    page += 1
+  end
+  result
+end
+
+def github_user(user)
+  params = access_params
+  result = RestClient.get(user['url'], {:params => params})
+  JSON.parse(result)
+end
+
+private
+
+def access_params(require_access_token=true)
+  params = {:per_page => RESULTS_PER_PAGE}
+  access_token = ENV['GH_ACCESS_TOKEN']
+  if access_token
+    params[:access_token] = access_token
+  elsif require_access_token
+    raise "Missing environment variable: GH_ACCESS_TOKEN"
+  end
+  params
+end

--- a/sclorg-permissions-test/lib/ldap.rb
+++ b/sclorg-permissions-test/lib/ldap.rb
@@ -1,0 +1,140 @@
+require 'ldap'
+
+HOST        = 'ldap.rdu.redhat.com'
+BASE_DN     = 'ou=Users, dc=redhat, dc=com'
+ATTRS = ['uid', 'mail', 'cn']
+
+
+def ldap_user_by_uid(uid)
+  user = nil
+  ldap = ldap_connect
+  ldap.bind do
+    ldap.search(BASE_DN, LDAP::LDAP_SCOPE_SUBTREE, "(uid=#{uid})", ATTRS) do |entry|
+      #email = entry.vals('mail')[0]
+      user = entry
+    end
+  end
+  user
+end
+
+def ldap_user_by_email(email)
+  user = nil
+  ldap = ldap_connect
+  ldap.bind do
+    ldap.search(BASE_DN, LDAP::LDAP_SCOPE_SUBTREE, "(mail=#{email})", ATTRS) do |entry|
+      user = entry
+    end
+  end
+  user
+end
+
+def ldap_users_by_name(givenName, sn, perfect_match=false)
+  users = []
+  ldap = ldap_connect
+  ldap.bind do
+    ldap.search(BASE_DN, LDAP::LDAP_SCOPE_SUBTREE, "(|(&(givenName=#{givenName}#{perfect_match ? '' : '*'})(sn=#{sn}))(cn=#{givenName}#{perfect_match ? ' ' : '*'}#{sn}))", ATTRS) do |entry|
+      users << entry
+    end
+  end
+  users
+end
+
+def ldap_users_by_last_name(sn)
+  users = []
+  ldap = ldap_connect
+  ldap.bind do
+    ldap.search(BASE_DN, LDAP::LDAP_SCOPE_SUBTREE, "(sn=#{sn})", ATTRS) do |entry|
+      users << entry
+    end
+  end
+  users
+end
+
+def valid_users(users)
+  valid_users = {}
+  users.each do |user|
+    user = github_user(user)
+    login = user['login']
+    name = user['name']
+    email = user['email']
+    begin
+      if email && email.end_with?('@redhat.com') && ldap_user_by_email(email)
+        # Found email in ldap
+        valid_users[login] = email
+      else
+        email = ldap_email(name, login)
+        if email
+          valid_users[login] = email
+        end
+      end
+    rescue Exception => e
+      puts "    #{login}: #{name} (Exception: #{e.message})"
+    end
+  end
+  return valid_users
+end
+
+private
+
+def ldap_email(name, login, verbose=true, allow_multiple=false)
+  first_name, middle_name, last_name = split_names(name)
+  users = nil
+  if last_name
+    users = ldap_users_by_name(first_name, last_name, true)
+    if users.length != 1 && !(allow_multiple && users.length > 1)
+      users = ldap_users_by_name(first_name, last_name)
+      if (users.length != 1 && middle_name) && !(allow_multiple && users.length > 1)
+        users = ldap_users_by_name(middle_name, last_name)
+        if users.length != 1 && !(allow_multiple && users.length > 1)
+          users = ldap_users_by_name(first_name, "#{middle_name} #{last_name}")
+        end
+      end
+      if users.length != 1 && !(allow_multiple && users.length > 1)
+        last_name_users = ldap_users_by_last_name(last_name)
+        users = last_name_users if last_name_users.length == 1
+      end
+    end
+  else
+    puts "No last name: #{login}: #{name}" if verbose
+  end
+  email = nil
+  if users
+    if users.length == 1 || (allow_multiple && users.length > 1)
+      email = users.first['mail'].first
+    else
+      puts "Not found or multiple matches: #{login}: #{name}" if verbose
+    end
+  end
+  return email
+end
+
+def split_names(name)
+  first_name = nil
+  last_name = nil
+  middle_name = nil
+  if name
+    ['(', '['].each do |c|
+      if name.index(c)
+        name = name[0..name.index(c) - 1]
+      end
+    end
+    names = name.strip.split(' ')
+    first_name = I18n.transliterate(names.first)
+    if first_name.end_with? '.'
+      first_name = first_name[0..-2]
+    end
+    if names.length > 1
+      last_name = I18n.transliterate(names.last)
+      if names.length > 2
+        middle_name = I18n.transliterate(names[1])
+      end
+    end
+  end
+  return [first_name, middle_name, last_name]
+end
+
+def ldap_connect
+  ldap = LDAP::Conn.new(HOST, LDAP::LDAP_PORT.to_i)
+  ldap.set_option(LDAP::LDAP_OPT_PROTOCOL_VERSION, 3)
+  ldap
+end

--- a/sclorg-permissions-test/report_invalid_users
+++ b/sclorg-permissions-test/report_invalid_users
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+
+$: << File.expand_path(File.dirname(__FILE__))
+
+require 'i18n'
+require 'lib/ldap'
+require 'lib/github'
+
+I18n.config.enforce_available_locales = false
+
+IMPERFECT_MATCH = '(imperfect match)'
+
+# List invalid collaborators of repositories from sclorg github organitation
+def list_invalid_users
+  puts "Potential Invalid GitHub Users:"
+  valid_user_names = {}
+  if !ENV.key?("GH_TEAM_TO_CHECK")
+    puts "ERROR: Missing GH_TEAM_TO_CHECK variable."
+    abort
+  end
+  user_whitelist=[]
+  if ENV.key?("GH_USER_WHITELIST")
+    user_whitelist=ENV["GH_USER_WHITELIST"].split(" ")
+    puts "Whitelisted users: #{user_whitelist}\n"
+  end
+  github_org_to_teams.each do |org_name, github_teams|
+    puts "Org: #{org_name}"
+    github_teams.each do |team|
+      if team['name'].include? ENV["GH_TEAM_TO_CHECK"]
+        puts "Team: #{team['name']}(#{team['id']})"
+        github_team_repos(team).each do |repo|
+          puts " Repository: #{repo['name']}"
+          users = github_repo_collaborators(repo)
+          valid_count = 0
+          invalid_count = 0
+          users.each do |user|
+            if user['permissions']['admin'] != true && user['permissions']['push'] != true
+              next
+            end
+            user = github_user(user)
+            login = user['login']
+            if valid_user_names.has_key?(login) || valid_user_names.has_key?(login + IMPERFECT_MATCH)
+              valid_count += 1
+              next
+            end
+            # User is whitelisted
+            if user_whitelist.include? login
+              valid_user_names[login] = true
+              valid_count += 1
+              next
+            end
+            name = user['name']
+            email = user['email']
+            begin
+              if email && email.end_with?('@redhat.com') && ldap_user_by_email(email)
+                # Found email in ldap
+                valid_user_names[login] = true
+                valid_count += 1
+              else
+                email = ldap_email(name, login, false)
+                if email
+                  valid_user_names[login] = true
+                  valid_count += 1
+                else
+                  email = ldap_email(name, login, false, true)
+                  if email
+                    valid_user_names[login + IMPERFECT_MATCH] = true
+                    valid_count += 1
+                  else
+                    puts "  #{login}: #{name}"
+                    invalid_count += 1
+                  end
+                end
+              end
+            rescue Exception => e
+              puts "    #{login}: #{name} (Exception: #{e.message})"
+            end
+          end
+          puts "  #invalid members: #{invalid_count}"
+        end
+      end
+    end
+    puts "\n\nValid GitHub Logins:"
+    puts valid_user_names.keys
+  end
+end
+
+list_invalid_users

--- a/sclorg-permissions-test/sclorg-permissions-test.yaml
+++ b/sclorg-permissions-test/sclorg-permissions-test.yaml
@@ -1,0 +1,55 @@
+- project:
+    name: github-repo-permissions
+    jobs:
+        - 'SCLo-test-github-permissions'
+
+- job-template:
+    name: 'SCLo-test-github-permissions'
+    project-type: freestyle
+    concurrent: false
+    logrotate:
+        numToKeep: 5
+    properties:
+      - github:
+           url: https://github.com/sclorg/rhscl-container-ci/tree/master/sclorg-permissions-test
+    scm:
+      - git:
+            url: https://github.com/sclorg/rhscl-container-ci.git
+            branches:
+              - 'refs/heads/master'
+            wipe-workspace: false
+            skip-tag: true
+    triggers:
+      - timed: 'H 12 * * *'
+    parameters:
+      - string:
+            name: GH_TEAM_TO_CHECK
+            default: Container images
+            description: "String to search to match team with container images, defaults to 'Container images'."
+      - string:
+            name: GH_USER_WHITELIST
+            default: openshift-bot centos-ci
+            description: "Whitespace separated list of github users to whitelist in testing, defaults to 'openshift-bot centos-ci'."
+    builders:
+      - shell: |
+            test_output=$(./sclorg-permissions-test/report_invalid_users)
+            if echo "${test_output}" | grep -q "#invalid members: [1-9]"; then
+              #echo "${test_output}"
+              exit 1
+            fi
+    publishers:
+      - email:
+            recipients: 'hhorak@redhat.com mskalick@redhat.com'
+
+    description: 'This test check repositories for container images in sclorg github organization. Only employees of Red Hat can have push or admin permissions.
+
+
+This job requires:
+
+- environmental variable GH_ACCESS_TOKEN which contains token for github user who has access to checked repositories
+
+- "json", "rest_client", "i18n" and "ldap" gems
+
+- connection to RH VPN (to access ldap.rdu.redhat.com)
+
+'


### PR DESCRIPTION
This PR adds job configuration for testing user permissions in repositories in sclorg.

IMPOV it is not possible to run it on ci.centos.org - because it needs access to ldap.rdu.redhat.com. However I would like to keep this config in same place as other jenkins jobs configurations.
@hhorak If you are OK with this, please merge.