### PR TITLE
Allow sclorg members to trigger build.

### DIFF
--- a/centos-ci-jenkins/yaml/triggers/github-pr.yaml
+++ b/centos-ci-jenkins/yaml/triggers/github-pr.yaml
@@ -6,6 +6,9 @@
             - hhorak
           white-list:
             - hhorak
+          org-list:
+            - sclorg
+          allow-whitelist-orgs-as-admins: true
           cron: 'H/10 * * * *'
           build-desc-template: "Checks whether PR does not break anything"
           trigger-phrase: '[test]'


### PR DESCRIPTION
Members of sclorg org are white listed (their PRs are tested automatically) and they are able to trigger build.

This requires centos-ci user to be member of sclorg - to be able to see who is member (invitation sent). @hhorak Who can accept this invitation?