### PR TITLE
Fixed squashing error, s2i images testing, python-cicoclient install,...

### DIFF
--- a/centos-ci-jenkins/yaml/builders/cico_install.sh
+++ b/centos-ci-jenkins/yaml/builders/cico_install.sh
@@ -11,5 +11,6 @@ fi
 source cicoclient/bin/activate
 
 if ! type cico >/dev/null 2>&1; then
+    pip install -U pip
     pip install python-cicoclient
 fi

--- a/centos-ci-jenkins/yaml/defaults/defaults.yaml
+++ b/centos-ci-jenkins/yaml/defaults/defaults.yaml
@@ -20,3 +20,8 @@
     properties:
       - github:
           url: https://github.com/{gituser}/{gitproject}
+      - raw:
+          xml: |
+            <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17.1">
+              <optOut>true</optOut>
+            </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>

--- a/centos-ci-jenkins/yaml/jobs/collection.yaml
+++ b/centos-ci-jenkins/yaml/jobs/collection.yaml
@@ -12,8 +12,6 @@
             gituser: '{gituser}'
             gitproject: '{gitproject}'
     triggers:
-        - weekly
-        - scm_fifteen_minutes
         - github-pr
     builders:
         - cico_install
@@ -25,8 +23,9 @@
         - generate_ssh_config
         - shell: |
             scp -F ssh_config -rp $(pwd) host:sources
-            ssh -F ssh_config host yum -y install docker perl git python-setuptools
+            ssh -F ssh_config host yum -y install docker perl git python-setuptools centos-release-scl-rh
+            ssh -F ssh_config host yum -y install source-to-image
             ssh -F ssh_config host service docker start
-            ssh -F ssh_config host make test -C sources
+            ssh -F ssh_config host make test SKIP_SQUASH=1 -C sources
     publishers:
         - cico_done

--- a/centos-ci-jenkins/yaml/triggers/github-pr.yaml
+++ b/centos-ci-jenkins/yaml/triggers/github-pr.yaml
@@ -9,6 +9,6 @@
           org-list:
             - sclorg
           allow-whitelist-orgs-as-admins: true
-          cron: 'H/10 * * * *'
+          cron: 'H/5 * * * *'
           build-desc-template: "Checks whether PR does not break anything"
-          trigger-phrase: '[test]'
+          trigger-phrase: '.*\[test\].*'


### PR DESCRIPTION
- fixed error during installing python-cicoclient (outdated pip)

- testing process requires variables from GitHub pull request builder plugin so only github-pr trigger is allowed

- set "Don't let user manually re-trigger this job" in job config (only github-pr should trigger these jobs) - not sure if this option works

- install source-to-image for s2i images testing

- disabled squashing - see sclorg/mariadb-container#9

- changed testing triggering regexp and shortened time for testing checking changes

@hhorak Please review and merge.