### PR TITLE
initialize git submodules

### DIFF
--- a/centos-ci-jenkins/yaml/jobs/collection.yaml
+++ b/centos-ci-jenkins/yaml/jobs/collection.yaml
@@ -26,6 +26,7 @@
             ssh -F ssh_config host yum -y install docker perl git python-setuptools centos-release-scl-rh
             ssh -F ssh_config host yum -y install source-to-image
             ssh -F ssh_config host service docker start
+            ssh -F ssh_config host 'cd sources && git submodule update --init'
             ssh -F ssh_config host make test SKIP_SQUASH=1 -C sources
     publishers:
         - cico_done


### PR DESCRIPTION
This would be useful for sclorg/postgresql-container#138, and for
further code sharing among container git repos.  Also, if there
are no submodules, this is empty operation so we should be fine to
add it without worries. (unless there is typo in the yaml file format).