### PR TITLE
rhel7: clean after testing

### DIFF
--- a/yaml/jobs/rhel-images-test.yaml
+++ b/yaml/jobs/rhel-images-test.yaml
@@ -33,4 +33,6 @@
               git checkout $remote/master
               git submodule update --init
               make test TARGET=rhel{release}
+              # clean everything (if the 'clean' target is defined)
+              make clean || :
             done


### PR DESCRIPTION
We don't have temporary VMs for RHEL tests yet; so try to cleanup
the leftovers.