### PR TITLE
Generate sources and push them into 'generated' branch

### DIFF
--- a/yaml/builders/image-build-push.yaml
+++ b/yaml/builders/image-build-push.yaml
@@ -8,6 +8,14 @@
             #!/bin/bash
             set -ex
 
+            # Push generated branch
+            ssh -F ssh_config host 'set -ex; cd sources; \
+              if git branch | grep -q generated; then \
+                GIT_URL=$(git remote -v | head -n 1 | tr '\t' ' ' | cut -f 2 -d' '); \
+                git remote add auth_origin ${{GIT_URL/#git:\/\//https:\/\/$GITHUB_TOKEN@}}; \
+                git push auth_origin generated; \
+              fi'
+
             # Push images
             ssh -F ssh_config host 'set -ex; \
               cd sources; make tag TARGET={targetOS} | tee output;'

--- a/yaml/builders/image-test.yaml
+++ b/yaml/builders/image-test.yaml
@@ -7,6 +7,17 @@
             #!/bin/bash
             set -ex
 
+            # Generate sources, commit changes into generated branch and show diff
+            ssh -F ssh_config host 'set -ex; \
+              cd sources; GIT_HASH=$(git rev-parse HEAD); \
+              git config user.name "SCLorg Jenkins"; git config user.email "sclorg@redhat.com"; \
+              if git checkout generated; then \
+                git submodule update; \
+                result="$(./update $GIT_HASH | tail -n 1)"; \
+                [ "$result" = "Nothing changed" ] || git diff generated~1 generated; \
+                git checkout -f $GIT_HASH && git submodule update; \
+              fi;'
+
             # Run make for base image and for each dependent image
             timeout 2h ssh -F ssh_config host 'set -ex; \
               cd sources; make test TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true; \

--- a/yaml/jobs/images-build.yaml
+++ b/yaml/jobs/images-build.yaml
@@ -9,6 +9,12 @@
 - job-template:
     name: 'rhscl-images-{name}-build'
     node: slave_rhel7_root
+    wrappers:
+      - timestamps
+      - credentials-binding:
+          - text:
+              variable: "GITHUB_TOKEN"
+              credential-id: 'ffe788e8-b346-45d8-a1a0-2370d12c2672'
     scm:
         - images-build:
             gituser: '{gituser}'


### PR DESCRIPTION
@pkubatrh @praiskup Please take a look if update script can be used this way. And I'm not doing any terrible mistake:-)

The code in `yaml/builders/` is only part of the code. And these parts are assembled - see:

for builds - https://github.com/sclorg/rhscl-container-ci/blob/master/yaml/jobs/images-build.yaml
for testing - https://github.com/sclorg/rhscl-container-ci/blob/master/yaml/jobs/images-test.yaml