### PR TITLE
Add ability to skip testing of some dependent image

### DIFF
--- a/yaml/builders/add_dependencies_remote.yaml
+++ b/yaml/builders/add_dependencies_remote.yaml
@@ -9,7 +9,7 @@
 
             curl --silent https://raw.githubusercontent.com/sclorg/rhscl-container-ci/master/configuration | while read scl namespace gituser gitproject trigger hub_namespace; do
 
-              if [[ "${{trigger}}" == *{name}* ]]; then
+              if [[ "${{trigger}}" == *{name}* ]] && echo "${{ghprbCommentBody}}" | grep -qv "\[-.*${{scl}}.*\]"; then
                 echo "Adding and fetching test_${{scl}}-${{namespace}} remote"
                 git remote add "test_${{scl}}-${{namespace}}" git://github.com/${{gituser}}/${{gitproject}}.git
                 git fetch "test_${{scl}}-${{namespace}}"


### PR DESCRIPTION
Adding '[-'*SCL*']' into a PR comment will skip testing of SCL (in
case that SCL uses image from PR repository as a base image)

- it expects SCL in form of first column of
https://github.com/sclorg/rhscl-container-ci/blob/master/configuration
file