### PR TITLE
Refresh token from git because it expires too often

### DIFF
--- a/yaml/builders/docker-hub-update.yaml
+++ b/yaml/builders/docker-hub-update.yaml
@@ -17,6 +17,9 @@
 
             # Update Docker Hub
             ssh -F ssh_config host << 'EOF'
+            # refresh the token that expires too often
+            curl -L https://url.corp.redhat.com/cs-dh-web-tok >/root/.docker_credentials/centos/hub-webapi-token
+
             set -ex;
             source dhwebapi/bin/activate
             cd sources


### PR DESCRIPTION
This is an easy solution for the problem that the token for updating docker hub web (description and summary) expires too often.