### PR TITLE
iterate over image_ids parsed from the logs

### DIFF
--- a/yaml/builders/image-build-push.yaml
+++ b/yaml/builders/image-build-push.yaml
@@ -27,8 +27,11 @@
             ssh -F ssh_config host bash << 'EOF'
             set -ex; cd sources;
 
-            image_id=$(cat output | grep -- '-> Tagging image' | cut -d' ' -f 4 | sed "s/'//g")
-            image_tags=$(docker image inspect "$image_id" --format '{{range $i, $tag := .RepoTags}}{{$tag}} {{end}}')
+            image_ids=$(cat output | grep -- '-> Tagging image' | cut -d' ' -f 4 | sed "s/'//g")
+            for image_id in $image_ids; do
+                image_tags+=$(docker image inspect "$image_id" --format '{{range $i, $tag := .RepoTags}}{{$tag}} {{end}}')
+            done
+
             for image in $image_tags; do
               case $image in
                 *:raw|*:squashed) continue ;;


### PR DESCRIPTION
as images that have multiple VERSIONS available will produce more than one image_id to push