### PR TITLE
fix memcached targetOS

### DIFF
--- a/yaml/jobs/collections/memcached-rh.yaml
+++ b/yaml/jobs/collections/memcached-rh.yaml
@@ -16,13 +16,13 @@
     release: 8
     jobs:
         - '{job_prefix}-{name}':
-            targetOS: 'centos'
+            targetOS: 'centos7'
             job_prefix: 'SCLo-container'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
         - '{job_prefix}-{name}':
-            targetOS: 'rhel'
+            targetOS: 'rhel7'
             job_prefix: 'rhscl-images'
             context: 'rhel7'
             not_automatic: false


### PR DESCRIPTION
since targetOS is directly used in make's TARGET argument
it needs to have the version of rhel/centos attached

Related: https://github.com/sclorg/memcached/pull/21