### PR TITLE
add rhel8

### DIFF
--- a/yaml/builders/prepare-centos.yaml
+++ b/yaml/builders/prepare-centos.yaml
@@ -19,7 +19,7 @@
             ConnectTimeout 10
 
             Host host
-              Hostname ${h}.ci.centos.org
+              Hostname ${{h}}.ci.centos.org
             EOF
 
             # Create script for cleanup
@@ -57,7 +57,7 @@
               # Hack docker-squash --version - 1.0.5 is required
               # (TEMPORARY FIX - until all images contain fixed https://github.com/sclorg/container-common-scripts/pull/100
               # https://github.com/sclorg/container-common-scripts/issues/101)
-              echo 'docker-squash() { if [ "$1" == "--version" ]; then echo "1.0.5"; else eval $(which docker-squash) $@ 1>&2; fi }' >> /root/.bashrc
+              echo 'docker-squash() {{ if [ "$1" == "--version" ]; then echo "1.0.5"; else eval $(which docker-squash) $@ 1>&2; fi }}' >> /root/.bashrc
               echo 'export -f docker-squash' >> /root/.bashrc
             EOF
 

--- a/yaml/builders/prepare-rhel.yaml
+++ b/yaml/builders/prepare-rhel.yaml
@@ -1,3 +1,5 @@
+# parameters:
+#   restag: name of resalloc tag
 - builder:
     name: 'prepare-rhscl-images'
     builders:
@@ -7,7 +9,7 @@
 
             rconnection="--connection http://10.0.149.99:49100/"
 
-            resalloc $rconnection ticket --tag rhel7 > ticket
+            resalloc $rconnection ticket --tag {restag} > ticket
             ticket=$(cat ticket)
             host=$(resalloc $rconnection ticket-wait "$ticket")
 
@@ -18,7 +20,7 @@
             ConnectTimeout 10
 
             Host host
-              Hostname ${host}
+              Hostname ${{host}}
               IdentityFile ~/.ssh/id_rsa_resalloc
             EOF
 
@@ -39,7 +41,7 @@
               # Hack docker-squash --version - 1.0.5 is required
               # (TEMPORARY FIX - until all images contain fixed https://github.com/sclorg/container-common-scripts/pull/100
               # https://github.com/sclorg/container-common-scripts/issues/101)
-              echo 'docker-squash() { if [ "$1" == "--version" ]; then echo "1.0.5"; else eval $(which docker-squash) $@ 1>&2; fi }' >> /root/.bashrc
+              echo 'docker-squash() {{ if [ "$1" == "--version" ]; then echo "1.0.5"; else eval $(which docker-squash) $@ 1>&2; fi }}' >> /root/.bashrc
               echo 'export -f docker-squash' >> /root/.bashrc
             EOF
 

--- a/yaml/jobs/collections/cassandra-rh.yaml
+++ b/yaml/jobs/collections/cassandra-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'cassandra-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/devtoolset-rh.yaml
+++ b/yaml/jobs/collections/devtoolset-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'devtoolset-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/golang-rh.yaml
+++ b/yaml/jobs/collections/golang-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'golang-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/httpd-rh.yaml
+++ b/yaml/jobs/collections/httpd-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'httpd-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/llvm-rh.yaml
+++ b/yaml/jobs/collections/llvm-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'llvm-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/mariadb-rh.yaml
+++ b/yaml/jobs/collections/mariadb-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'mariadb-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/memcached-rh.yaml
+++ b/yaml/jobs/collections/memcached-rh.yaml
@@ -16,14 +16,14 @@
     release: 8
     jobs:
         - '{job_prefix}-{name}':
-            targetOS: 'centos7'
             job_prefix: 'SCLo-container'
+            targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
         - '{job_prefix}-{name}':
-            targetOS: 'rhel7'
             job_prefix: 'rhscl-images'
+            targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
@@ -32,5 +32,12 @@
             name: 'memcached-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
+            not_automatic: false
+            trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'memcached-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
             not_automatic: false
             trigger_phrase: 'test'

--- a/yaml/jobs/collections/mongodb-rh.yaml
+++ b/yaml/jobs/collections/mongodb-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'mongodb-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/mysql-rh.yaml
+++ b/yaml/jobs/collections/mysql-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'mysql-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/nginx-rh.yaml
+++ b/yaml/jobs/collections/nginx-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'nginx-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/nodejs-rh.yaml
+++ b/yaml/jobs/collections/nodejs-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'nodejs-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/passenger-rh.yaml
+++ b/yaml/jobs/collections/passenger-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'passenger-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/perl-rh.yaml
+++ b/yaml/jobs/collections/perl-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'perl-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/php-rh.yaml
+++ b/yaml/jobs/collections/php-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'php-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/postgresql-rh.yaml
+++ b/yaml/jobs/collections/postgresql-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'postgresql-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/python-rh.yaml
+++ b/yaml/jobs/collections/python-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'python-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/redis-rh.yaml
+++ b/yaml/jobs/collections/redis-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'redis-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/ror-rh.yaml
+++ b/yaml/jobs/collections/ror-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'ror-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/ruby-rh.yaml
+++ b/yaml/jobs/collections/ruby-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'ruby-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/s2i-rh.yaml
+++ b/yaml/jobs/collections/s2i-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 's2i-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/template
+++ b/yaml/jobs/collections/template
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: '%SCL%-%NAMESPACE%-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/thermostat-rh.yaml
+++ b/yaml/jobs/collections/thermostat-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'thermostat-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/collections/varnish-rh.yaml
+++ b/yaml/jobs/collections/varnish-rh.yaml
@@ -51,3 +51,10 @@
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
+        - '{job_prefix}-{name}':
+            name: 'varnish-rh-rhel8'
+            job_prefix: 'rhscl-images'
+            targetOS: 'rhel8'
+            context: 'rhel8'
+            not_automatic: false
+            trigger_phrase: 'test'

--- a/yaml/jobs/images-build.yaml
+++ b/yaml/jobs/images-build.yaml
@@ -22,7 +22,8 @@
     builders:
         - add_dependencies_remote:
             name: '{name}'
-        - prepare-{job_prefix}
+        - prepare-{job_prefix}:
+            restag: 'rhel7'
         - shell: |
             #!/bin/bash
             set -ex

--- a/yaml/jobs/images-test.yaml
+++ b/yaml/jobs/images-test.yaml
@@ -23,7 +23,8 @@
     builders:
         - add_dependencies_remote:
             name: '{name}'
-        - prepare-{job_prefix}
+        - prepare-{job_prefix}:
+            restag: '{targetOS}'
         - shell: |
             #!/bin/bash
             set -ex

--- a/yaml/jobs/misc/container-common-scripts-test.yaml
+++ b/yaml/jobs/misc/container-common-scripts-test.yaml
@@ -14,9 +14,17 @@
             targetOS: 'rhel7'
             not_automatic: true
             trigger_phrase: 'test'
+        - '{job_prefix}-container-common-scripts-test':
+            job_prefix: 'rhscl-images'
+            job_suffix: '-rhel8'
+            targetOS: 'rhel8'
+            not_automatic: true
+            trigger_phrase: 'test'
 
 - job-template:
-    name: '{job_prefix}-container-common-scripts-test'
+    name: '{job_prefix}-container-common-scripts-test{job_suffix}'
+    id: '{job_prefix}-container-common-scripts-test'
+    job_suffix: ''
     node: sclo-sig||slave_rhel7_root
     wrappers:
       - wrappers-{job_prefix}
@@ -30,7 +38,8 @@
             not_automatic: '{not_automatic}'
             trigger_phrase: '{trigger_phrase}'
     builders:
-        - prepare-{job_prefix}
+        - prepare-{job_prefix}:
+            restag: '{targetOS}'
         - shell: |
             #!/bin/bash
             set -ex


### PR DESCRIPTION
 There is one potential problem with this PR:
https://github.com/sclorg/rhscl-container-ci/blob/master/yaml/builders/add_dependencies_remote.yaml

By default {name} is substitued with collection name e.g. "mysql-rh", but for rhel8 it is substitued by "mysql-rh-rhel8" and this is probably not desired change.