### PR TITLE
Disable testing conu on rhel8

### DIFF
--- a/yaml/builders/image-test.yaml
+++ b/yaml/builders/image-test.yaml
@@ -20,14 +20,14 @@
             # Run make for base image and for each dependent image
             timeout 2h ssh -F ssh_config host 'set -ex; \
               cd sources; make test TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true; \
-              [ -f ./test/run-conu ] && make test-with-conu TARGET={targetOS} TAG_ON_SUCCESS=true; \
+              [ -f ./test/run-conu ] && [ "{targetOS}" != "rhel8" ] && make test-with-conu TARGET={targetOS} TAG_ON_SUCCESS=true; \
               for remote in $(git remote | grep test_); do \
                 git checkout $remote/master; \
                 git submodule update --init; \
                 versions=$(grep "VERSIONS = " Makefile | sed "s|VERSIONS = ||"); \
                 echo "Testing ${{remote#test_}}/master - version ${{versions##* }}"; \
                 make test TARGET={targetOS} VERSIONS=${{versions##* }}; \
-                [ -f ./test/run-conu ] && make test-with-conu TARGET={targetOS} TAG_ON_SUCCESS=true; \
+                [ -f ./test/run-conu ] && [ "{targetOS}" != "rhel8" ] && make test-with-conu TARGET={targetOS} TAG_ON_SUCCESS=true; \
               done; \
               git checkout -f origin/master;'
 


### PR DESCRIPTION
testing conu does not work on rhel8 from docker-py or libpod reason.
The issue is tracked here: https://github.com/user-cont/conu/issues/374

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>