### PR TITLE
Fix image-test-openshift-4

### DIFF
--- a/yaml/builders/image-test-openshift-4.yaml
+++ b/yaml/builders/image-test-openshift-4.yaml
@@ -1,7 +1,7 @@
 # Requires:
 # {targetOS}
 - builder:
-    name: 'image-test-openshift'
+    name: 'image-test-openshift-4'
     builders:
         - shell: |
             #!/bin/bash
@@ -9,4 +9,4 @@
 
             # Run make for base image and for each dependent image
             timeout 2h ssh -F ssh_config host 'set -ex; \
-              cd sources; make test-openshift TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true;'
+              cd sources; make test-openshift-4 TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true;'

--- a/yaml/jobs/images-test.yaml
+++ b/yaml/jobs/images-test.yaml
@@ -35,6 +35,7 @@
 
         - image-{trigger_phrase}:
             targetOS: '{targetOS}'
+            trigger_phrase: '{trigger_phrase}'
     publishers:
         - upload-diff:
             gituser: '{gituser}'


### PR DESCRIPTION
This commit fixes JJB image trigger.

It was my misunderstanding about how JJB works.

OpenShift 4 tests are now triggered based on these changes https://github.com/sclorg/s2i-php-container/pull/286

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>