### PR TITLE
Enable testing nodejs on OpenShift 4

### DIFF
--- a/yaml/jobs/collections/nodejs-rh.yaml
+++ b/yaml/jobs/collections/nodejs-rh.yaml
@@ -45,6 +45,13 @@
             not_automatic: true
             trigger_phrase: 'test-openshift'
         - '{job_prefix}-{name}':
+            job_prefix: 'rhscl-images'
+            name: 'nodejs-rh-openshift-4'
+            targetOS: 'rhel7'
+            context: 'rhel7 - openshift - 4'
+            not_automatic: true
+            trigger_phrase: 'test-openshift-4'
+        - '{job_prefix}-{name}':
             job_prefix: 'SCLo-container'
             name: 'nodejs-rh-fedora'
             targetOS: 'fedora'


### PR DESCRIPTION
Enable testing nodejs container in OpenShift 4
environment because of there can be used
tag: Required-by: which is needed for testing.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>