### PR TITLE
Download kubeconfig and secret

### DIFF
--- a/yaml/builders/image-test-openshift-4.yaml
+++ b/yaml/builders/image-test-openshift-4.yaml
@@ -7,6 +7,11 @@
             #!/bin/bash
             set -ex
 
+            # Download kubeconfig
+            curl -L https://url.corp.redhat.com/ocp-kubeconfig >/root/.kube/config
+            # Download kubepasswd
+            curl -L https://url.corp.redhat.com/kube >/root/.kube/ocp-kube
+
             # Run make for base image and for each dependent image
             timeout 2h ssh -F ssh_config host 'set -ex; \
               cd sources; make test-openshift-4 TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true;'


### PR DESCRIPTION
We do not need to reinstall slave each new OCP4 release
therefore download secrets from url.corp.redhat.com

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>