### PR TITLE
Use Docker container for updating JJB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM fedora:31
+
+ENV NAME=rhscl-container-ci \
+    RELEASE=1 \
+    ARCH=x86_64 \
+    HOME="/home/rhscl-container-ci"
+ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+
+RUN dnf install -y python3-pip
+
+WORKDIR ${HOME}
+
+COPY ./ ${HOME}
+
+RUN pip3 install -r requirements.txt
+
+CMD ${HOME}/run.sh $JENKINS_CMD

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: build run
+IMAGE_NAME := quay.io/rhscl/rhscl-container-ci
+CUR_DIR = `pwd`
+JENKINS_CMD :=
+build:
+	docker build --tag ${IMAGE_NAME} .
+
+run:
+	docker run \
+	-v ${CUR_DIR}/:/home/rhscl-container-ci \
+	-e JENKINS_CMD=${JENKINS_CMD} \
+	${IMAGE_NAME}
+

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ Now tests are run in two Jenkins instances:
 
 To use scripts in this repository to update jobs in Jenkins you need:
 
-* `virtualenv` command, supplied through the `python-virtualenv` RPM
+* `docker` command
 
-JJB will be installed into a virtual environment under this directory, so is
+JJB will be installed into a container environment, so is
 safe to run on any system.
 
 ## Updating all jobs
 
 The provided script can update the Jenkins jobs over the API by running JJB.
 
-    ./run.sh update
+    make run JENKINS_CMD=update
 
 To access Jenkins using JJB you have to provide configuration file. So if
 files `jenkins_jobs.ini` and `jenkins_jobs_rhscl.ini` don't exist they are
@@ -47,7 +47,7 @@ Note: [SCLo-sig](https://wiki.centos.org/SpecialInterestGroup/SCLo)
 credentials for [ci.centos.org](ci.centos.org) can be found in the home
 directory on slave01.ci.centos.org.
 
-## Using run.sh
+## Using run.sh in docker container
 
 `run.sh` is simple wrapper for `jenkins-jobs` command. It supports `update`,
 `test` and `delete` commands. And according specified name prefix of jobs it
@@ -56,21 +56,21 @@ for commands.
 
 To test the configuration of one job, run:
 
-    ./run.sh test rhscl-images-ruby-rh
+    make run JENKINS_CMD="test rhscl-images-ruby-rh"
     echo $?
 
 Once happy with the result, to test your config change on a single job, run:
 
-    ./run.sh update rhscl-images-ruby-rh
+    make run JENKINS_CMD=update rhscl-images-ruby-rh"
 
 During updating jobs you can select jobs by globbing. For example to update
 jobs configured for CentOS CI run
 
-    ./run.sh update SCLo-*
+    make run JENKINS_CMD="update SCLo-*"
 
 or to update the RHEL related jobs in different jenkins instance run
 
-    ./run.sh update rhscl-*
+    make run JENKINS_CMD="update rhscl-*"
 
 ## Generating jobs
 
@@ -104,7 +104,7 @@ regenerating all project files.**
 For regenerating all project files (if you really know what you do; see a comment above), run:
 ```
 rm yaml/jobs/collections/*yaml
-./run test
+make run JENKINS_CMD="test"
 ```
 
 ## How to add tests for a new image
@@ -114,7 +114,7 @@ When a new image is created and we want to add testing of it. Push/move image re
 1. Create jenkins job - the easiest way is to add a new entry to `./configuration` 
 file and run `./run.sh` (missing project files are generated):
 
-    `./run.sh update`
+    `make run JENKINS_CMD=update`
 
     Then a PR should include `./configuration` and the newly created file
     `./yaml/jobs/collections/<newspec>`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jenkins-job-builder==2.0.2

--- a/run.sh
+++ b/run.sh
@@ -5,35 +5,9 @@
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
-VIRTUALENV=virtualenv-3
-
-# Generate a virtualenv to install JJB into, in a gitignored dir
-if [ ! -d $THISDIR/local ]; then
-  if ! rpm -q python3-virtualenv &>/dev/null; then
-    echo "python3-virtualenv must be installed to run this script"
-    exit 1
-  fi
-
-  # newer Fedora versions use /bin/virtualenv
-  test -x "/usr/bin/$VIRTUALENV" || VIRTUALENV=virtualenv
-
-  $VIRTUALENV --system-site-packages "$THISDIR/local"
-else
-  echo >&2 " !! re-using virtualenv $THISDIR/local !!"
-fi
-
-source $THISDIR/local/bin/activate
-
-# Install JJB into the venv
-if ! pip show jenkins-job-builder >/dev/null 2>&1; then
-  echo "Installing jenkins-job-builder into an isolated virtualenv..."
-  # If we used latest version here (2.0.7 at the time of writing this) our we
-  # would have to update 'release-vm.yaml' file so it contains
-  # 'generict-script' hash (not string!) with 'file-path: ./.cleanup.sh'
-  # option.  But the uploaded build config would be mistreated by our (rather
-  # old) jenkins instances and the parameter would be in turn ignored entirely.
-  # TODO: because ^^ update jenkins instances first!
-  pip install jenkins-job-builder==2.0.2
+if [[ -z "$JENKINS_CMD" ]]; then
+  echo "You have to specify command as JENKINS_CMD environment variable."
+  exit 1
 fi
 
 # Generate a JJB config files


### PR DESCRIPTION
This pull request runs JJB jobs inside the container.

README.md is also updated.

I would prefer to push the image into quay.io/rhscl/rhscl-container-ci and then create
a private docker file with RedHat certificates.

Then the user can only pull an image and run commands for updating JJB.

What do you think about my proposal?

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>