### PR TITLE
Fix downloading OpenShift credentials

### DIFF
--- a/yaml/builders/image-test-openshift-4.yaml
+++ b/yaml/builders/image-test-openshift-4.yaml
@@ -7,11 +7,14 @@
             #!/bin/bash
             set -ex
 
+            # Run make for base image and for each dependent image
+            timeout 2h ssh -F ssh_config host bash 'EOF'
+            set -ex
+
             # Download kubeconfig
             curl -L https://url.corp.redhat.com/ocp-kubeconfig >/root/.kube/config
             # Download kubepasswd
             curl -L https://url.corp.redhat.com/kube >/root/.kube/ocp-kube
-
-            # Run make for base image and for each dependent image
-            timeout 2h ssh -F ssh_config host 'set -ex; \
-              cd sources; make test-openshift-4 TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true;'
+            cd sources
+            make test-openshift-4 TARGET={targetOS} UPDATE_BASE=1 TAG_ON_SUCCESS=true
+            EOF


### PR DESCRIPTION
Credentials are downloaded into host
but not to the slave.

This commit  fixes this bug

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>