### PR TITLE
Remove CentOS7 openshift 3 tests

### DIFF
--- a/yaml/jobs/nightly-builds.yaml
+++ b/yaml/jobs/nightly-builds.yaml
@@ -22,11 +22,6 @@
           tests: test
           build_name: nightly_build
       - '{build_name}_{os}':
-          os: centos7
-          targetOS: rhel7
-          tests: test-openshift
-          build_name: nightly_build_openshift_3
-      - '{build_name}_{os}':
           os: rhel7
           targetOS: rhel7
           tests: test-openshift
@@ -74,10 +69,11 @@
             git config --global user.email "sclorg@redhat.com"'
 
           # Run make for base image and for each dependent image
-          timeout 3h ssh -F ssh_config host 'set -ex; \
+          timeout 5h ssh -F ssh_config host 'set -ex; \
             cd sources; bash daily_tests/daily_scl_tests.sh {os} {tests}'
 
     publishers:
       - send-email:
           os: '{os}'
+          tests: '{tests}'
       - release-vm

--- a/yaml/publishers/send-email.yaml
+++ b/yaml/publishers/send-email.yaml
@@ -1,5 +1,6 @@
 # Requires:
 # {os}
+# {tests}
 - publisher:
     name: 'send-email'
     publishers:
@@ -13,7 +14,7 @@
             ssh -F ssh_config host 'set -ex; \
             cd sources; \
             python3 ./send_results.py \
-            /tmp/daily_scl_tests/results {os} \
+            /tmp/daily_scl_tests/results {os}-{tests} \
             "phracek@redhat.com, pkubat@redhat.com, hhorak@redhat.com, vdanek@redhat.com, lzachar@redhat.com, rhscl-container-qe@redhat.com" "phracek@redhat.com"'
 
             # Wait two seconds before cleaning machine.


### PR DESCRIPTION
Remove CentOS7 openshift 3 tests,

Increase timeout to 5 hours.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>