### PR TITLE
Jenkins CI have two different triggers.

### DIFF
--- a/yaml/jobs/collections/devtoolset-rh.yaml
+++ b/yaml/jobs/collections/devtoolset-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: devtoolset-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-centos_centos7-rh-trigger'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'devtoolset-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'devtoolset-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'devtoolset-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'devtoolset-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'devtoolset-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/golang-rh.yaml
+++ b/yaml/jobs/collections/golang-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: golang-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'golang-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'golang-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'golang-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'golang-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'golang-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/httpd-rh.yaml
+++ b/yaml/jobs/collections/httpd-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: httpd-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'httpd-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'httpd-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'httpd-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'httpd-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'httpd-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/llvm-rh.yaml
+++ b/yaml/jobs/collections/llvm-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: llvm-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-centos_centos7-rh-trigger'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'llvm-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'llvm-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'llvm-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'llvm-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'llvm-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/mariadb-rh.yaml
+++ b/yaml/jobs/collections/mariadb-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: mariadb-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mariadb-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mariadb-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mariadb-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mariadb-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'mariadb-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/memcached-rh.yaml
+++ b/yaml/jobs/collections/memcached-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: memcached
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-centos_centos7-rh-trigger'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'memcached-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'memcached-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'memcached-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'memcached-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'memcached-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/mongodb-rh.yaml
+++ b/yaml/jobs/collections/mongodb-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: mongodb-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mongodb-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mongodb-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mongodb-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mongodb-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'mongodb-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/mysql-rh.yaml
+++ b/yaml/jobs/collections/mysql-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: mysql-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mysql-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mysql-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'mysql-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'mysql-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'mysql-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/nginx-rh.yaml
+++ b/yaml/jobs/collections/nginx-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: nginx-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'nginx-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'nginx-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'nginx-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'nginx-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'nginx-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/nodejs-rh.yaml
+++ b/yaml/jobs/collections/nodejs-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-nodejs-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'nodejs-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'nodejs-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'nodejs-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'nodejs-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'nodejs-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/perl-rh.yaml
+++ b/yaml/jobs/collections/perl-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-perl-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'perl-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'perl-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'perl-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'perl-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'perl-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/php-rh.yaml
+++ b/yaml/jobs/collections/php-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-php-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'php-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'php-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'php-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'php-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'php-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/postgresql-rh.yaml
+++ b/yaml/jobs/collections/postgresql-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: postgresql-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'postgresql-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'postgresql-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'postgresql-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'postgresql-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'postgresql-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/python-rh.yaml
+++ b/yaml/jobs/collections/python-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-python-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'python-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'python-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'python-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'python-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'python-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/redis-rh.yaml
+++ b/yaml/jobs/collections/redis-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: redis-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'redis-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'redis-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'redis-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'redis-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'redis-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/ruby-rh.yaml
+++ b/yaml/jobs/collections/ruby-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-ruby-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'ruby-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'ruby-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'ruby-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'ruby-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'ruby-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/s2i-rh.yaml
+++ b/yaml/jobs/collections/s2i-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: s2i-base-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-centos_centos7-rh-trigger'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 's2i-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 's2i-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 's2i-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 's2i-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 's2i-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/template
+++ b/yaml/jobs/collections/template
@@ -14,52 +14,52 @@
     gitproject: %GITPROJECT%
     gituser: %GITUSER%
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: '%TRIGGER%'
             hub_namespace: '%HUB_NAMESPACE%'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: '%SCL%-%NAMESPACE%-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: '%SCL%-%NAMESPACE%-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: '%SCL%-%NAMESPACE%-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: '%SCL%-%NAMESPACE%-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: '%SCL%-%NAMESPACE%-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/collections/varnish-rh.yaml
+++ b/yaml/jobs/collections/varnish-rh.yaml
@@ -14,52 +14,52 @@
     gitproject: varnish-container
     gituser: sclorg
     jobs:
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             targetOS: 'centos7'
             context: 'centos7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             targetOS: 'rhel7'
             context: 'rhel7'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}-build':
+        - 'rhscl-images-{name}-build':
             job_prefix: 'rhscl-images'
             project_trigger: 'rhscl-images-s2i-rh-build'
             hub_namespace: 'docker.io/centos'
             context: 'centos7'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'varnish-rh-openshift'
             targetOS: 'centos7'
             context: 'centos7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'varnish-rh-openshift'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift'
             not_automatic: true
             trigger_phrase: 'test-openshift'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             job_prefix: 'rhscl-images'
             name: 'varnish-rh-openshift-4'
             targetOS: 'rhel7'
             context: 'rhel7 - openshift - 4'
             not_automatic: true
             trigger_phrase: 'test-openshift-4'
-        - '{job_prefix}-{name}':
+        - 'SCLo-container-{name}':
             job_prefix: 'SCLo-container'
             name: 'varnish-rh-fedora'
             targetOS: 'fedora'
             context: 'fedora'
             not_automatic: false
             trigger_phrase: 'test'
-        - '{job_prefix}-{name}':
+        - 'rhscl-images-{name}':
             name: 'varnish-rh-rhel8'
             job_prefix: 'rhscl-images'
             targetOS: 'rhel8'

--- a/yaml/jobs/images-build.yaml
+++ b/yaml/jobs/images-build.yaml
@@ -8,7 +8,7 @@
 # {hub_namespace}
 # {context}
 - job-template:
-    name: '{job_prefix}-{name}-build'
+    name: 'rhscl-images-{name}-build'
     node: slave_rhel7_root
     parameters:
       - string:

--- a/yaml/jobs/images-test.yaml
+++ b/yaml/jobs/images-test.yaml
@@ -8,8 +8,60 @@
 # {trigger_phrase}
 # {context}
 - job-template:
-    name: '{job_prefix}-{name}'
-    node: sclo-sig||slave_rhel7_root
+    name: 'SCLo-container-{name}'
+    node: sclo-sig
+    parameters:
+        - string:
+              name: CI_MESSAGE
+              default: ''
+              description: "CI message from the Red Hat CI plugin."
+        - string:
+              name: CI_SCRIPTS
+              default: "./ci-scripts/jenkins_ci"
+              description: "Path to Jenkins CI scripts."
+    wrappers:
+      - wrappers-{job_prefix}
+    scm:
+        - images-pull-test:
+            gituser: '{gituser}'
+            gitproject: '{gitproject}'
+    triggers:
+        - github-pr-{job_prefix}:
+            gituser: '{gituser}'
+            gitproject: '{gitproject}'
+            trigger_phrase: '{trigger_phrase}'
+            not_automatic: '{not_automatic}'
+            context: '{context}'
+    builders:
+        - clone-ci-scripts
+        - update_github_pr:
+            name: '{name}'
+            gitproject: '{gitproject}'
+            gituser: '{gituser}'
+            context: '{context}'
+        - add_dependencies_remote:
+            name: '{name}'
+            gitproject: '{gitproject}'
+            gituser: '{gituser}'
+        - prepare-{job_prefix}:
+            restag: '{targetOS}'
+        - image-{trigger_phrase}:
+            targetOS: '{targetOS}'
+            trigger_phrase: '{trigger_phrase}'
+    publishers:
+        - upload-diff:
+            gituser: '{gituser}'
+            gitproject: '{gitproject}'
+            trigger_phrase: '{trigger_phrase}'
+        - release-vm
+        - upload-log-{job_prefix}:
+            gituser: '{gituser}'
+            gitproject: '{gitproject}'
+            context: '{context}'
+
+- job-template:
+    name: 'rhscl-images-{name}'
+    node: slave_rhel7_root
     parameters:
         - string:
               name: CI_MESSAGE

--- a/yaml/scm/images-pull-test.yaml
+++ b/yaml/scm/images-pull-test.yaml
@@ -1,0 +1,12 @@
+# parameters:
+#   gituser: name of github user or organization
+#   gitproject: name of a repository to test
+- scm:
+    name: images-pull-test
+    scm:
+      - git:
+          url: git://github.com/{gituser}/{gitproject}.git
+          refspec: '+refs/pull/*:refs/remotes/origin/pr/*'
+          branches:
+             - '${{ghprbActualCommit}}'
+          skip-tag: True


### PR DESCRIPTION
CentOS CI still uses GitHub PR Builder.
RHEL CI uses FedMsg builder.

Therefore two templates are needed for know.

image-pull-test.yaml was missing and therefore
CentOS CI does not work properly. It is fixed
by two templates

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>